### PR TITLE
Changed format language to make comments not red

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Two example filetemplates
 
 You can add a `string` argument to the keybind you are using to define a static folder in which you want the new folder to be created.
 
-```json
+```jsonc
 {
   "key": "ctrl+0", //or your preffered keybind,
   "command": "FT.createFolderStructure",


### PR DESCRIPTION
Changed the format language to `jsonc` for the snippet with comments since `json` shows comments as syntax errors.

Before

![image](https://user-images.githubusercontent.com/20955511/114939528-3beb2700-9e49-11eb-837c-b61024eeca8e.png)

After

![image](https://user-images.githubusercontent.com/20955511/114939539-41487180-9e49-11eb-830a-115552dba4f5.png)
