### PR TITLE
Fix #61 Add json schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "Other"
   ],
   "activationEvents": [
+    "onFileSystem:.ftsettings.json",
     "onCommand:FT.createFolderStructure",
     "onCommand:FT.openGlobalFolder"
   ],
@@ -60,15 +61,119 @@
           "type": "array",
           "scope": "window",
           "default": [],
-          "description": "Configure as many structures as you would like."
+          "description": "An array of objects where one object equals one natural file system folder structure.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "$ref": "https://raw.githubusercontent.com/Huuums/vscode-folder-templates/master/src/schemas/defs.json#definitions/string_nonempty"
+              },
+              "customVariables": {
+                "type": "array",
+                "description": "Custom variables that will be replaced upon folder creation",
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "https://raw.githubusercontent.com/Huuums/vscode-folder-templates/master/src/schemas/defs.json#definitions/cvar"
+                }
+              },
+              "omitParentDirectory": {
+                "type": "boolean",
+                "default": false,
+                "description": "If set to true FT will create all files directly inside the current folder instead of creating a new folder and all the files inside of it"
+              },
+              "omitFTName": {
+                "type": "boolean",
+                "default": false,
+                "description": "If set to true FT will not ask for a component name. (Can only be set to true if omitParentDirectory is true as well)"
+              },
+              "structure": {
+                "type": "array",
+                "description": "Every object in this array represents a file or folder that will be created. To create an empty directory, set the `template` property to `EmptyDirectory`",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+
+                  "required": [
+                    "fileName"
+                  ],
+
+                  "properties": {
+                    "fileName": {
+                      "$ref": "https://raw.githubusercontent.com/Huuums/vscode-folder-templates/master/src/schemas/defs.json#definitions/string_nonempty",
+                      "description": "Filenames can contain interpolated custom variables or can be assigned to subfolders by typing the full path. If a subfolder does not exist in the full path provided, it will be created at runtime",
+                      "examples": [
+                        "<FTName>.jsx",
+                        "root/subfolderA/subfolderB/test.js",
+                        "<CustomVar>"
+                      ]
+                    },
+                    "template": {
+                      "description": "",
+                      "anyOf": [
+                        {
+                          "const": "EmptyDirectory"
+                        },
+                        {
+                          "$ref": "https://raw.githubusercontent.com/Huuums/vscode-folder-templates/master/src/schemas/defs.json#definitions/string_nonempty"
+                        }
+                      ],
+                      "examples": [
+                        "Typescript Functional Component",
+                        "IndexFile",
+                        "EmptyDirectory"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "if": {
+              "properties": {
+                "omitParentDirectory": { "const": true }
+              }
+            },
+            "then": {
+              "properties": {
+                  "omitFTName": { "enum": [ true ]
+                }
+              }
+            }
+          }
         },
         "folderTemplates.fileTemplates": {
           "type": "object",
           "scope": "window",
-          "default": {}
+          "default": {},
+          "examples": [
+            "\"Indexfile\": \"import <FTName> from './<FTName>'\n\nexport default <FTName>;"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^.+$": {
+              "anyOf": [
+                {
+                  "$ref": "https://raw.githubusercontent.com/Huuums/vscode-folder-templates/master/src/schemas/defs.json#definitions/string_nonempty"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "default" : ""
+                  }
+                }
+              ]
+            }
+          }
         }
       }
-    }
+    },
+    "jsonValidation": [
+      {
+        "fileMatch": ".ftsettings.json",
+        "url": "./src/schemas/ftsettings.json"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/src/schemas/defs.json
+++ b/src/schemas/defs.json
@@ -1,0 +1,21 @@
+{
+    "title": "JSON schema for the .ftsettings configuration file",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "string_nonempty": {
+            "type": "string",
+            "default": "",
+            "minLength": 1,
+            "pattern": "^([^\\s].*[^\\s]*)$"
+        },
+        "cvar": {
+            "type": "string",
+            "examples": [
+                "mainColor=>red",
+                "secondaryColor=>#cecece"
+            ],
+            "description": "A key-value pair (kvp) declaration delimited by '=>'. The left hand side is the name of the variable and the right hand side is the value to replace it",
+            "pattern": "^[\\w]+=>[^\\s]+$"
+        }
+    }
+}

--- a/src/schemas/ftsettings.json
+++ b/src/schemas/ftsettings.json
@@ -1,0 +1,41 @@
+{
+    "title": "JSON schema for the .ftsettings configuration file",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "name" : {
+            "$ref": "./defs.json/#/definitions/string_nonempty",
+            "description": "If a value is not provided, the default is the name of the parent folder",
+            "title": "Name of the folder template"
+        },
+        "customVariables" : {
+            "type": "array",
+            "description": "Custom variables that will be replaced upon folder creation",
+            "uniqueItems": true,
+            "items": {
+                "$ref": "./defs.json/#/definitions/cvar"
+            }
+        },
+        "omitParentDirectory": {
+            "type": "boolean",
+            "default": false,
+            "description": "If set to true FT will create all files directly inside the current folder instead of creating a new folder and all the files inside of it"
+        },
+        "omitFTName": {
+            "type": "boolean",
+            "default": false,
+            "description": "If set to true FT will not ask for a component name. (Can only be set to true if omitParentDirectory is true as well)"
+        }
+    },
+    "if": {
+        "properties": {
+            "omitParentDirectory": { "const": true }
+        }
+    },
+    "then": {
+        "properties": {
+            "omitFTName": { "enum": [true] }
+        }
+    }
+}


### PR DESCRIPTION
The following is a PR to take care of #61 
I wasn't sure about the verbiage you would want for the descriptions (these are the details that populate on hover or when showing suggestion details), so you might have to sift through those and tidy them up to your preference.

The only thing that may not be familiar to you, I don't know so I can only assume, is the `$ref` pulling from github. vscode fortunately allows you to pull json schemas from a store, or just a regular url, or from relative paths. In this case the vscode `settings.json` path is not in the extension path so you can't use relative paths, but you can call it from the repo it's stored in :) I say all that to say, it will not work until that specific url is in this repo. It's currently set to master, but you can change that to your develop branch if you want to play around with it. 

Otherwise, it's your typical schema setup and I additionally updated the `activationEvents` as discussed so that any `.ftsettings` file has the benefit of autocomplete and hints as well.

I didn't want to be that kind of guy to ask for something and then not contribute, so if you want to follow up or expand on any of these concepts let me know. 

Cheers and thanks again!