### PR TITLE
filter .DS_Store file

### DIFF
--- a/src/lib/extensionHelpers.ts
+++ b/src/lib/extensionHelpers.ts
@@ -59,7 +59,7 @@ export const getTemplatesFromFS = (folderPath: PathLike) => {
       const structure = convertFolderContentToStructure(
         contents,
         `${folderPath}/${file.name}`
-      ).filter((val) => val.fileName !== ".ftsettings.json" && val.fileName !== ".DS_Store");
+      ).filter((val) => val.fileName !== ".ftsettings.json" && !val.fileName.endsWith(".DS_Store"));
 
       return {
         ...settings,

--- a/src/lib/extensionHelpers.ts
+++ b/src/lib/extensionHelpers.ts
@@ -59,7 +59,7 @@ export const getTemplatesFromFS = (folderPath: PathLike) => {
       const structure = convertFolderContentToStructure(
         contents,
         `${folderPath}/${file.name}`
-      ).filter((val) => val.fileName !== ".ftsettings.json");
+      ).filter((val) => val.fileName !== ".ftsettings.json" && val.fileName !== ".DS_Store");
 
       return {
         ...settings,


### PR DESCRIPTION
macOS generates a .DS_Store file for each folder opened with finder, but the file means nothing to the template, so filter it out.